### PR TITLE
Fix check HAS_ENTITLEMENTS

### DIFF
--- a/pyzule.py
+++ b/pyzule.py
@@ -240,10 +240,7 @@ if args.f:
     ENT_PATH = os.path.join(APP_PATH, 'pyzule.entitlements')
     try:
         run(f"ldid -e {BINARY_PATH} > {ENT_PATH}", shell=True, check=True, stderr=DEVNULL)
-        if os.path.getsize(ENT_PATH) > 0:
-            HAS_ENTITLEMENTS = 1
-        else:
-            HAS_ENTITLEMENTS = 0
+        HAS_ENTITLEMENTS = 1 if os.path.getsize(ENT_PATH) > 0 else 0
     except CalledProcessError:
         with open(ENT_PATH, "w") as epf:
             HAS_ENTITLEMENTS = 0

--- a/pyzule.py
+++ b/pyzule.py
@@ -240,7 +240,10 @@ if args.f:
     ENT_PATH = os.path.join(APP_PATH, 'pyzule.entitlements')
     try:
         run(f"ldid -e {BINARY_PATH} > {ENT_PATH}", shell=True, check=True, stderr=DEVNULL)
-        HAS_ENTITLEMENTS = 1
+        if os.path.getsize(ENT_PATH) > 0:
+            HAS_ENTITLEMENTS = 1
+        else:
+            HAS_ENTITLEMENTS = 0
     except CalledProcessError:
         with open(ENT_PATH, "w") as epf:
             HAS_ENTITLEMENTS = 0


### PR DESCRIPTION
Some app create file entitlements successfully but the entitlements file has no content so restore entitlements fails.